### PR TITLE
workaround for tabu errors

### DIFF
--- a/physikon/Bestaetigung_Unternehmen.tex
+++ b/physikon/Bestaetigung_Unternehmen.tex
@@ -10,12 +10,11 @@
 \usepackage{fontspec}
 \usepackage{polyglossia}
 \setmainlanguage{german}
-
+\usepackage{array}[=2016-10-06]
 \usepackage{microtype}
 \usepackage{graphicx}
 
 \usepackage{tabu}
-\usepackage{array}
 \usepackage{colortbl}
 \usepackage{siunitx}
 

--- a/physikon/Rechnung_Unternehmen.tex
+++ b/physikon/Rechnung_Unternehmen.tex
@@ -11,11 +11,12 @@
 \usepackage{polyglossia}
 \setmainlanguage{german}
 
+\usepackage{array}[=2016-10-06]
+
 \usepackage{microtype}
 \usepackage{graphicx}
 
 \usepackage{tabu}
-\usepackage{array}
 \usepackage{colortbl}
 \usepackage{siunitx}
 


### PR DESCRIPTION
Die tabu-Umgebung ist aus irgendeinem Grund nicht mehr kompatibel mit latex 2018. Mit diesem fix läuft alles durch, wir sollten das ganze aber mal ordentlich fixen!