### PR TITLE
Update Bestätigungsdokument regarding PhysiKon 2026.

### DIFF
--- a/physikon/Bestaetigung_Unternehmen.tex
+++ b/physikon/Bestaetigung_Unternehmen.tex
@@ -27,7 +27,7 @@
 \definecolor{grau}{rgb}{0.830,0.865,0.857}
 
 \author{Das PhysiKon Team}
-\setkomavar{subject}{Bestätigung Ihrer Anmeldung zur PhysiKon 2025}
+\setkomavar{subject}{Bestätigung Ihrer Anmeldung zur PhysiKon 2026}
 
 \begin{document}
 \begin{letter}{%
@@ -38,8 +38,8 @@
 % ANREDE
 \opening{Guten Tag <Vorname Nachname>,}
 % BRIEFTEXT
-hiermit bestätigen wir Ihre Anmeldung zur PhysiKon 2025 (Onlinevortrag im Zeitraum 14.-16.04.25, 
-Präsenzmesse an der TU Dortmund am 17.04.25). 
+hiermit bestätigen wir Ihre Anmeldung zur PhysiKon 2026.
+% (Onlinevortrag an der TU Dortmund am 14.-16.04.25, Präsenzmesse an der TU Dortmund 17.04.25)
 Wir freuen uns sehr, Sie als Aussteller begrüßen zu dürfen!
 
 Im Folgenden erhalten Sie alle wichtigen Informationen zur Durchführung der Messe:
@@ -65,8 +65,8 @@ Im Folgenden erhalten Sie alle wichtigen Informationen zur Durchführung der Mes
       \item Gewünschte Zusatzqualifikationen
       \item Link zu Ihrem Karriereportal (falls vorhanden)
     \end{itemize}
-    \item \textbf{Onlinevortrag:} Im Vorfeld zur Berufsmesse bieten wir Ihnen die Möglichkeit sich im Rahmen eines einstündigen Vortrags interessierten
-    Studierenden vorzustellen. Um die Einrichtung des Zoom-Meetings kümmern wir uns. 
+    % \item \textbf{Onlinevortrag:} Im Vorfeld zur Berufsmesse bieten wir Ihnen die Möglichkeit sich im Rahmen eines einstündigen Vortrags interessierten
+    % Studierenden vorzustellen. Um die Einrichtung des Zoom-Meetings kümmern wir uns. 
     \item \textbf{Jobbörse:} Auf unserer \href{https://pep-dortmund.org/jobboerse/}{Jobbörse} können 
     Sie offene Stellen, Praktika oder Traineeprogramme veröffentlichen. Damit die Anzeigen möglichst 
     aktuell sind, werden wir Sie einige Wochen vor der Veranstaltung bitten, uns Stellenangebote zuzusenden. 
@@ -78,9 +78,9 @@ Im Folgenden erhalten Sie alle wichtigen Informationen zur Durchführung der Mes
     ausreichende Parkmöglichkeiten. Wir werden Ihnen kurz vor der Veranstaltung noch mal detaillierte Informationen für die Anfahrt und Anlieferungsparkplätze für sperriges Ausstellungsmaterial zusenden. 
     \item \textbf{Anreise mit der Bahn:} Die S-Bahn-Haltestelle "Dortmund Universität" befindet sich in unmittelbarer Nähe zum Veranstaltungsort.
     Am Tag der PhysiKon werden wir den Weg ausreichend beschildern.
-    Vom Dortmunder Hauptbahnhof erreichen Sie die TU Dortmund alle 20 Minuten mit der Linie S1 von Gleis 7.
-    \item \textbf{Ausstellerbeitrag:} Die Teilnahme am gesamten Programm der PhysiKon (Onlinevortrag und Messestand) kostet 1300 Euro.
-    Der Ausstellerbeitrag für eine Online-Teilnahme (nur Onlinevortrag ohne Messestand) beträgt 800 Euro.
+    Vom Dortmunder Hauptbahnhof erreichen Sie die TU Dortmund alle 15 Minuten mit der Linie S1 von Gleis 7.
+    \item \textbf{Ausstellerbeitrag:} Die Teilnahme am gesamten Programm der PhysiKon kostet 1300 Euro. % (Onlinevortrag und Messestand)
+    % Der Ausstellerbeitrag für eine Online-Teilnahme (nur Onlinevortrag ohne Messestand) beträgt 800 Euro.
     Die Rechnung über den Ausstellerbeitrag und alle Zahlungsinformationen erhalten Sie einige Wochen vor der Veranstaltung.
     \textbf{Senden Sie uns bitte eine korrekte Rechnungsadresse zu, falls diese von der Unternehmensadresse abweicht.}
 \end{itemize}


### PR DESCRIPTION
Update the Bestätigungsdokument regarding PhysiKon 2026. Since online presentations are not planned, the corresponding parts are left as comments.